### PR TITLE
guard clause for new database setups

### DIFF
--- a/forum-after/lib/tasks/multitenant.rake
+++ b/forum-after/lib/tasks/multitenant.rake
@@ -4,6 +4,7 @@ namespace :multitenant do
   db_tasks.each do |task_name|
     desc "Run #{task_name} for each tenant"
     task task_name => %w[environment db:load_config] do
+      next unless ActiveRecord::Base.connection.table_exists?('tenants')
       Tenant.find_each do |tenant|
         puts "Running #{task_name} for tenant#{tenant.id} (#{tenant.subdomain})"
         tenant.scope_schema { Rake::Task[task_name].execute }


### PR DESCRIPTION
Migrating from scratch causes the following error, since a call to `Tenants.find_each` is made before the `tenants` table is created.

```
rake db:migrate
rake aborted!
PG::Error: ERROR:  relation "tenants" does not exist
LINE 4:              WHERE a.attrelid = '"tenants"'::regclass
                                        ^
:             SELECT a.attname, format_type(a.atttypid, a.atttypmod), d.adsrc, a.attnotnull
              FROM pg_attribute a LEFT JOIN pg_attrdef d
                ON a.attrelid = d.adrelid AND a.attnum = d.adnum
             WHERE a.attrelid = '"tenants"'::regclass
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum

Tasks: TOP => db:migrate => multitenant:db:migrate
(See full trace by running task with --trace)
```